### PR TITLE
Fixes

### DIFF
--- a/config-vdms.json
+++ b/config-vdms.json
@@ -6,6 +6,10 @@
     "port": 55555, // Default is 55555
     "max_simultaneous_clients": 20, // Default is 500
 
+    // Tune the number of maximum attempts when acquiring the
+    // reader writer lock for metadata changes.
+    "max_lock_attempts": 10,
+
     // Database paths
     "pmgd_path": "db/graph", // This will be an IP address in the future
     "png_path": "db/images/pngs/",

--- a/src/PMGDQueryHandler.cc
+++ b/src/PMGDQueryHandler.cc
@@ -386,6 +386,8 @@ int PMGDQueryHandler::query_node(const protobufs::QueryNode &qn,
     if (!bool(ni)) {
         set_response(response, PMGDCmdResponse::Empty,
                        "Null search iterator\n");
+        if (has_link)
+            start_ni->reset();
         return -1;
     }
 
@@ -413,6 +415,8 @@ int PMGDQueryHandler::query_node(const protobufs::QueryNode &qn,
         if (bool(*tni)) {  // Not unique and that is an error here.
             set_response(response, PMGDCmdResponse::NotUnique,
                            "Query response not unique\n");
+            if (has_link)
+                start_ni->reset();
             delete tni;
             return -1;
         }

--- a/src/PMGDQueryHandler.cc
+++ b/src/PMGDQueryHandler.cc
@@ -49,12 +49,14 @@ void PMGDQueryHandler::init()
 {
     std::string dbname = VDMSConfig::instance()
                         ->get_string_value("pmgd_path", "default_pmgd");
+    unsigned attempts = VDMSConfig::instance()
+                        ->get_int_value("max_lock_attempts", RWLock::MAX_ATTEMPTS);
  
     // Create a db
     _db = new PMGD::Graph(dbname.c_str(), PMGD::Graph::Create);
 
     // Create the query handler here assuming database is valid now.
-    _dblock = new RWLock();
+    _dblock = new RWLock(attempts);
 }
 
 void PMGDQueryHandler::destroy()
@@ -77,10 +79,20 @@ std::vector<PMGDCmdResponses>
 
     // Assuming one query handler handles one TX at a time.
     _readonly = readonly;
-    if (_readonly)
-        _dblock->read_lock();
-    else
-        _dblock->write_lock();
+    try {
+        if (_readonly)
+            _dblock->read_lock();
+        else
+            _dblock->write_lock();
+    }
+    catch (Exception e) {
+        PMGDCmdResponses &resp_v = responses[0];
+        PMGDCmdResponse *response = new PMGDCmdResponse();
+        set_response(response, PMGDCmdResponse::Exception,
+                        e.name + std::string(": ") +  e.msg);
+        resp_v.push_back(response);
+        return responses;
+    }
 
     for (const auto cmd : cmds) {
         PMGDCmdResponse *response = new PMGDCmdResponse();

--- a/src/PMGDQueryHandler.cc
+++ b/src/PMGDQueryHandler.cc
@@ -57,6 +57,16 @@ void PMGDQueryHandler::init()
     _dblock = new RWLock();
 }
 
+void PMGDQueryHandler::destroy()
+{
+    if (_db) {
+        delete _db;
+        delete _dblock;
+        _db = NULL;
+        _dblock = NULL;
+    }
+}
+
 std::vector<PMGDCmdResponses>
               PMGDQueryHandler::process_queries(const PMGDCmds &cmds,
               int num_groups, bool readonly)

--- a/src/PMGDQueryHandler.h
+++ b/src/PMGDQueryHandler.h
@@ -119,6 +119,7 @@ namespace VDMS {
 
     public:
         static void init();
+        static void destroy();
         PMGDQueryHandler() { _tx = NULL; _readonly = true; }
 
         // The vector here can contain just one JL command but will be surrounded by

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -104,4 +104,6 @@ Server::~Server()
 {
     _cm->shutdown();
     delete _cm;
+    PMGDQueryHandler::destroy();
+    VDMSConfig::destroy();
 }

--- a/tests/json_queries.cc
+++ b/tests/json_queries.cc
@@ -100,6 +100,7 @@ TEST(AddImage, simpleAdd)
 
     EXPECT_EQ(json_response[0]["AddImage"]["status"].asString(), "0");
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(AddImage, simpleAddx10)
@@ -151,6 +152,7 @@ TEST(AddImage, simpleAddx10)
         EXPECT_EQ(json_response[i]["AddImage"]["status"].asString(), "0");
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(QueryHandler, AddAndFind){
@@ -290,4 +292,5 @@ TEST(QueryHandler, AddAndFind){
     EXPECT_EQ(sum_found_before, sum_found_after);
     EXPECT_EQ(count_found_before, count_found_after);
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }

--- a/tests/pmgd_queries.cc
+++ b/tests/pmgd_queries.cc
@@ -251,8 +251,8 @@ TEST(PMGDQueryHandler, queryTestList)
 
         vector<vector<protobufs::CommandResponse *>> responses = qh.process_queries(cmds, query_count, true);
         int nodecount, propcount = 0;
-        for (int i = 0; i < query_count; ++i) {
-            vector<protobufs::CommandResponse *> response = responses[i];
+        for (int q = 0; q < query_count; ++q) {
+            vector<protobufs::CommandResponse *> response = responses[q];
             for (auto it : response) {
                 EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
@@ -458,8 +458,8 @@ TEST(PMGDQueryHandler, queryNeighborTestList)
 
         vector<vector<protobufs::CommandResponse *>> responses = qh.process_queries(cmds, query_count, true);
         int nodecount, propcount = 0;
-        for (int i = 0; i < query_count; ++i) {
-            vector<protobufs::CommandResponse *> response = responses[i];
+        for (int q = 0; q < query_count; ++q) {
+            vector<protobufs::CommandResponse *> response = responses[q];
             for (auto it : response) {
                 EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
@@ -560,8 +560,8 @@ TEST(PMGDQueryHandler, queryConditionalNeighborTestList)
 
         vector<vector<protobufs::CommandResponse *>> responses = qh.process_queries(cmds, query_count, true);
         int nodecount, propcount = 0;
-        for (int i = 0; i < query_count; ++i) {
-            vector<protobufs::CommandResponse *> response = responses[i];
+        for (int q = 0; q < query_count; ++q) {
+            vector<protobufs::CommandResponse *> response = responses[q];
             for (auto it : response) {
                 EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
@@ -838,8 +838,8 @@ TEST(PMGDQueryHandler, queryNeighborLinksTestList)
 
         vector<vector<protobufs::CommandResponse *>> responses = qh.process_queries(cmds, query_count, true);
         int nodecount, propcount = 0;
-        for (int i = 0; i < query_count; ++i) {
-            vector<protobufs::CommandResponse *> response = responses[i];
+        for (int q = 0; q < query_count; ++q) {
+            vector<protobufs::CommandResponse *> response = responses[q];
             for (auto it : response) {
                 EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
@@ -954,8 +954,8 @@ TEST(PMGDQueryHandler, queryNeighborLinksReuseTestList)
         vector<vector<protobufs::CommandResponse *>> responses = qh.process_queries(cmds, query_count, true);
         int nodecount = 0, propcount = 0;
         int totnodecount = 0, totpropcount = 0;
-        for (int i = 0; i < query_count; ++i) {
-            vector<protobufs::CommandResponse *> response = responses[i];
+        for (int q = 0; q < query_count; ++q) {
+            vector<protobufs::CommandResponse *> response = responses[q];
             for (auto it : response) {
                 EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
@@ -1081,8 +1081,8 @@ TEST(PMGDQueryHandler, querySortedNeighborLinksReuseTestList)
         int nodecount = 0, propcount = 0;
         int totnodecount = 0, totpropcount = 0;
         bool firstquery = true;
-        for (int i = 0; i < query_count; ++i) {
-            vector<protobufs::CommandResponse *> response = responses[i];
+        for (int q = 0; q < query_count; ++q) {
+            vector<protobufs::CommandResponse *> response = responses[q];
             for (auto it : response) {
                 EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
@@ -1162,8 +1162,8 @@ TEST(PMGDQueryHandler, queryTestListLimit)
 
         vector<vector<protobufs::CommandResponse *>> responses = qh.process_queries(cmds, query_count, true);
         int nodecount, propcount = 0;
-        for (int i = 0; i < query_count; ++i) {
-            vector<protobufs::CommandResponse *> response = responses[i];
+        for (int q = 0; q < query_count; ++q) {
+            vector<protobufs::CommandResponse *> response = responses[q];
             for (auto it : response) {
                 EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {

--- a/tests/pmgd_queries.cc
+++ b/tests/pmgd_queries.cc
@@ -163,7 +163,7 @@ TEST(PMGDQueryHandler, addTest)
         for (int i = 0; i < query_count; ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
-                ASSERT_EQ(it->error_code(), protobufs::CommandResponse::Success) << "Unsuccessful TX";
+                EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << "Unsuccessful TX";
                 if (it->r_type() == protobufs::NodeID) {
                     long nodeid = it->op_int_value();
                     EXPECT_EQ(nodeid, nodeids++) << "Unexpected node id";
@@ -176,6 +176,7 @@ TEST(PMGDQueryHandler, addTest)
         }
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 void print_property(const string &key, const protobufs::Property &p)
@@ -253,7 +254,7 @@ TEST(PMGDQueryHandler, queryTestList)
         for (int i = 0; i < query_count; ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
-                ASSERT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
+                EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
                     auto mymap = it->prop_values();
                     for(auto m_it : mymap) {
@@ -274,6 +275,7 @@ TEST(PMGDQueryHandler, queryTestList)
         EXPECT_EQ(propcount, 2) << "Not enough properties read";
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(PMGDQueryHandler, queryTestAverage)
@@ -316,7 +318,7 @@ TEST(PMGDQueryHandler, queryTestAverage)
         for (int i = 0; i < query_count; ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
-                ASSERT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
+                EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::Average) {
                     EXPECT_EQ(it->op_float_value(), 76.5) << "Average didn't match expected for four patients' age";
                 }
@@ -324,6 +326,7 @@ TEST(PMGDQueryHandler, queryTestAverage)
         }
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(PMGDQueryHandler, queryTestUnique)
@@ -376,7 +379,7 @@ TEST(PMGDQueryHandler, queryTestUnique)
         query_count++;
 
         vector<vector<protobufs::CommandResponse *>> responses = qh.process_queries(cmds, query_count, true);
-        ASSERT_EQ(responses.size(), 1) << "Expecting an error return situation";
+        EXPECT_EQ(responses.size(), 1) << "Expecting an error return situation";
         for (int i = 0; i < responses.size(); ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
@@ -386,6 +389,7 @@ TEST(PMGDQueryHandler, queryTestUnique)
         }
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(PMGDQueryHandler, queryNeighborTestList)
@@ -457,7 +461,7 @@ TEST(PMGDQueryHandler, queryNeighborTestList)
         for (int i = 0; i < query_count; ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
-                ASSERT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
+                EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
                     auto mymap = it->prop_values();
                     for(auto m_it : mymap) {
@@ -478,6 +482,7 @@ TEST(PMGDQueryHandler, queryNeighborTestList)
         EXPECT_EQ(propcount, 1) << "Not enough properties read";
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(PMGDQueryHandler, queryConditionalNeighborTestList)
@@ -558,7 +563,7 @@ TEST(PMGDQueryHandler, queryConditionalNeighborTestList)
         for (int i = 0; i < query_count; ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
-                ASSERT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
+                EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
                     auto mymap = it->prop_values();
                     for(auto m_it : mymap) {
@@ -579,6 +584,7 @@ TEST(PMGDQueryHandler, queryConditionalNeighborTestList)
         EXPECT_EQ(propcount, 1) << "Not enough properties read";
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(PMGDQueryHandler, queryNeighborTestSum)
@@ -650,7 +656,7 @@ TEST(PMGDQueryHandler, queryNeighborTestSum)
         for (int i = 0; i < query_count; ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
-                ASSERT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
+                EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::Sum) {
                     EXPECT_EQ(it->op_int_value(), 150) << "Sum didn't match expected for two patients' age";
                 }
@@ -658,6 +664,7 @@ TEST(PMGDQueryHandler, queryNeighborTestSum)
         }
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(PMGDQueryHandler, addConstrainedTest)
@@ -734,18 +741,19 @@ TEST(PMGDQueryHandler, addConstrainedTest)
         // Since PMGD queries always generate one response per command,
         // we can do the following:
         protobufs::CommandResponse *resp = responses[0][0];  // TxBegin
-        ASSERT_EQ(resp->error_code(), protobufs::CommandResponse::Success) << "Unsuccessful TX";
+        EXPECT_EQ(resp->error_code(), protobufs::CommandResponse::Success) << "Unsuccessful TX";
         resp = responses[1][0];  // Conditional add
-        ASSERT_EQ(resp->error_code(), protobufs::CommandResponse::Exists) << resp->error_msg();
+        EXPECT_EQ(resp->error_code(), protobufs::CommandResponse::Exists) << resp->error_msg();
         EXPECT_EQ(resp->op_int_value(), 1) << "Unexpected node id for conditional add";
         resp = responses[2][0];  // Regular add
-        ASSERT_EQ(resp->error_code(), protobufs::CommandResponse::Success) << resp->error_msg();
+        EXPECT_EQ(resp->error_code(), protobufs::CommandResponse::Success) << resp->error_msg();
         EXPECT_EQ(resp->op_int_value(), 5) << "Unexpected node id for add";
         resp = responses[3][0];  // Regular add edge
-        ASSERT_EQ(resp->error_code(), protobufs::CommandResponse::Success) << resp->error_msg();
+        EXPECT_EQ(resp->error_code(), protobufs::CommandResponse::Success) << resp->error_msg();
         EXPECT_EQ(resp->op_int_value(), 3) << "Unexpected edge id for add";
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(PMGDQueryHandler, queryNeighborLinksTestList)
@@ -833,7 +841,7 @@ TEST(PMGDQueryHandler, queryNeighborLinksTestList)
         for (int i = 0; i < query_count; ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
-                ASSERT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
+                EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
                     auto mymap = it->prop_values();
                     for(auto m_it : mymap) {
@@ -854,6 +862,7 @@ TEST(PMGDQueryHandler, queryNeighborLinksTestList)
         EXPECT_EQ(propcount, 1) << "Not enough properties read";
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(PMGDQueryHandler, queryNeighborLinksReuseTestList)
@@ -948,7 +957,7 @@ TEST(PMGDQueryHandler, queryNeighborLinksReuseTestList)
         for (int i = 0; i < query_count; ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
-                ASSERT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
+                EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
                     propcount = 0;
                     auto mymap = it->prop_values();
@@ -977,6 +986,7 @@ TEST(PMGDQueryHandler, queryNeighborLinksReuseTestList)
         EXPECT_EQ(totpropcount, 3) << "Not enough total properties read";
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(PMGDQueryHandler, querySortedNeighborLinksReuseTestList)
@@ -1074,7 +1084,7 @@ TEST(PMGDQueryHandler, querySortedNeighborLinksReuseTestList)
         for (int i = 0; i < query_count; ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
-                ASSERT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
+                EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
                     propcount = 0;
                     auto mymap = it->prop_values();
@@ -1107,6 +1117,7 @@ TEST(PMGDQueryHandler, querySortedNeighborLinksReuseTestList)
         EXPECT_EQ(totpropcount, 3) << "Not enough total properties read";
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(PMGDQueryHandler, queryTestListLimit)
@@ -1154,7 +1165,7 @@ TEST(PMGDQueryHandler, queryTestListLimit)
         for (int i = 0; i < query_count; ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
-                ASSERT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
+                EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::List) {
                     auto mymap = it->prop_values();
                     for(auto m_it : mymap) {
@@ -1175,6 +1186,7 @@ TEST(PMGDQueryHandler, queryTestListLimit)
         EXPECT_EQ(propcount, 2) << "Not enough properties read";
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }
 
 TEST(PMGDQueryHandler, queryTestSortedLimitedAverage)
@@ -1221,7 +1233,7 @@ TEST(PMGDQueryHandler, queryTestSortedLimitedAverage)
         for (int i = 0; i < query_count; ++i) {
             vector<protobufs::CommandResponse *> response = responses[i];
             for (auto it : response) {
-                ASSERT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
+                EXPECT_EQ(it->error_code(), protobufs::CommandResponse::Success) << it->error_msg();
                 if (it->r_type() == protobufs::Average) {
                     EXPECT_EQ(static_cast<int>(it->op_float_value()), 73) << "Average didn't match expected for three middle patients' age";
                 }
@@ -1229,4 +1241,5 @@ TEST(PMGDQueryHandler, queryTestSortedLimitedAverage)
         }
     }
     VDMSConfig::destroy();
+    PMGDQueryHandler::destroy();
 }

--- a/tests/python/TestEntities.py
+++ b/tests/python/TestEntities.py
@@ -98,13 +98,13 @@ class TestEntities(unittest.TestCase):
                                     ["threadid"], thID)
 
     def test_runMultipleAdds(self):
-
         simultaneous = 1000;
         thread_arr = []
         for i in range(1,simultaneous):
             thread_add = Thread(target=self.addEntity,args=(i,) )
             thread_add.start()
             thread_arr.append(thread_add)
+            time.sleep(0.002)
 
         for i in range(1,simultaneous):
             thread_find = Thread(target=self.findEntity,args=(i,) )

--- a/tests/python/config-tests.json
+++ b/tests/python/config-tests.json
@@ -5,6 +5,10 @@
     // Network
     "port": 55557, // Default is 55555
 
+    // Tune the number of maximum attempts when acquiring the
+    // reader writer lock for metadata changes.
+    "max_lock_attempts": 20,
+
     // Database paths
     "pmgd_path": "db/test-graph",
     "png_path": "db/images/pngs/",


### PR DESCRIPTION
In case of errors, the lack of PMGDQueryHandler pointer cleanup was causing problems. And not being able to set the number of attempts for RWLock was annoying for some application use cases. This pull request address both the problems.