### PR TITLE
Change default Image format

### DIFF
--- a/src/ImageCommand.cc
+++ b/src/ImageCommand.cc
@@ -103,7 +103,7 @@ int AddImage::construct_protobuf(PMGDQuery& query,
     }
 
     std::string img_root = _storage_tdb;
-    VCL::Image::Format vcl_format = VCL::Image::Format::TDB;
+    VCL::Image::Format vcl_format = img.get_image_format();
 
     std::string format = get_value<std::string>(cmd, "format", "");
     if (cmd.isMember("format")) {


### PR DESCRIPTION
TDB format only performs better with very large images, and it is usually not the first choice for users, forcing them to explicitly change for format for every insertion or getting error messages. It is better to just go with JPG as the default until we start seeing more use cases showing the benefits of the format.