### PR TITLE
Remove ImageData from unit-test build script

### DIFF
--- a/tests/SConscript
+++ b/tests/SConscript
@@ -64,7 +64,6 @@ query_tests = testenv.Program(
                   '../src/vcl/Exception.o',
                   '../src/vcl/TDBObject.o',
                   '../src/vcl/Image.o',
-                  '../src/vcl/ImageData.o',
                   '../src/vcl/TDBImage.o',
                   '../src/vcl/Video.o',
                   '../src/vcl/DescriptorSet.o',


### PR DESCRIPTION
Build script of the unit-test still includes ImageData as dependency.
This causes linking process for unit-tests to fail.

ImageData class has been removed in a previous patch, so it is no longer
needed. This patch removes the dependency.

Signed-off-by: mahircg <mahircan.guel@intel.com>