### PR TITLE
Do not push 'read' operation on Video constructor

### DIFF
--- a/include/vcl/Video.h
+++ b/include/vcl/Video.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <list>
 #include <memory> // For shared_ptr
 #include <string>
 
@@ -292,7 +293,7 @@ namespace VCL {
 
         Codec _codec; // (h.264, etc).
 
-        std::vector<std::shared_ptr<Operation>> _operations;
+        std::list<std::shared_ptr<Operation>> _operations;
 
     /*  *********************** */
     /*        OPERATION         */
@@ -522,6 +523,14 @@ namespace VCL {
          *  @param Video_id  The full path to the Video to be read
          */
         void read(const std::string &video_id );
+
+        /**
+         *  Checks whether the video pointed by the current video_id has
+         *  already been read.
+         *
+         * @return true if video was read, false otherwise
+         */
+        bool is_read(void);
 
         /**
          *  Performs the set of operations that have been requested

--- a/include/vcl/Video.h
+++ b/include/vcl/Video.h
@@ -517,14 +517,6 @@ namespace VCL {
     /*       UTILITIES          */
     /*  *********************** */
         /**
-         *  Stores a Read Operation in the list of operations
-         *    to perform
-         *
-         *  @param Video_id  The full path to the Video to be read
-         */
-        void read(const std::string &video_id );
-
-        /**
          *  Checks whether the video pointed by the current video_id has
          *  already been read.
          *

--- a/src/vcl/Video.cc
+++ b/src/vcl/Video.cc
@@ -49,10 +49,10 @@ Video::Video() :
 {
 }
 
-Video::Video(const std::string& video_id)
+Video::Video(const std::string& video_id) :
+    Video()
 {
     _video_id = video_id;
-    read(_video_id); // push the read operation
 }
 
 Video::Video(void* buffer, long size) :
@@ -69,7 +69,6 @@ Video::Video(void* buffer, long size) :
         throw VCLException(OpenFailed, "Cannot create temporary file");
 
     _video_id = uname;
-    read(_video_id); // push the read operation
 }
 
 Video::Video(const Video &video)
@@ -89,8 +88,8 @@ Video::Video(const Video &video)
     _frames     = video._frames;
     _operations = video._operations;
 
-    for (int i = 0; i < video._operations.size(); ++i)
-        _operations.push_back(video._operations[i]);
+    for (const auto& op : video._operations)
+        _operations.push_back(op);
 }
 
 Video& Video::operator=(Video vid)
@@ -102,7 +101,6 @@ Video& Video::operator=(Video vid)
 Video::~Video()
 {
     _operations.clear();
-    _operations.shrink_to_fit();
 }
 
     /*  *********************** */
@@ -201,12 +199,35 @@ void Video::read(const std::string &video_id)
     _operations.push_back(std::make_shared<Read>());
 }
 
+bool Video::is_read(void)
+{
+    return (_size.frame_count > 0);
+}
+
 void Video::perform_operations()
 {
     try
     {
-        for (int x = 0; x < _operations.size(); ++x) {
-            std::shared_ptr<Operation> op = _operations[x];
+        // At this point, there are three different potential callees:
+        //
+        // - An object is instantiated through the default constructor with
+        //   no name: an exception is thrown as no operations can be applied.
+        //
+        // - An object is instantiated through one-arg string constructor,
+        //   but has no operations set explicitely (i.e. when calling
+        //   get_frame_count()): a 'read' operation is pushed to the head of
+        //   the queue.
+        //
+        // - An object is instantiated through any of the non-default
+        //   constructors, and has pushed operations explicitely: a 'read'
+        //   operation is pushed to the head of the queue.
+        if ((_operations.empty() || _operations.front()->get_type() != READ)
+            && !is_read()) {
+            if (_video_id.empty())
+                throw VCLException(OpenFailed, "video_id is not initialized");
+            _operations.push_front(std::make_shared<Read>());
+        }
+        for (const auto& op : _operations) {
             if ( op == NULL )
                 throw VCLException(ObjectEmpty, "Nothing to be done");
             (*op)(this);

--- a/src/vcl/Video.cc
+++ b/src/vcl/Video.cc
@@ -193,12 +193,6 @@ void Video::set_dimensions(const cv::Size& dimensions)
     /*       UTILITIES          */
     /*  *********************** */
 
-void Video::read(const std::string &video_id)
-{
-    _video_id = video_id;
-    _operations.push_back(std::make_shared<Read>());
-}
-
 bool Video::is_read(void)
 {
     return (_size.frame_count > 0);

--- a/tests/unit_tests/Video_test.cc
+++ b/tests/unit_tests/Video_test.cc
@@ -93,9 +93,7 @@ protected:
 TEST_F(VideoTest, DefaultConstructor)
 {
     VCL::Video video_data;
-    long input_frame_count = video_data.get_frame_count();
-
-    ASSERT_EQ(input_frame_count, 0);
+    ASSERT_THROW(video_data.get_frame_count(), VCL::Exception);
 }
 
 TEST_F(VideoTest, StringConstructor)


### PR DESCRIPTION
Currently, in some of the constructors of Video class, a 'read' operation is
enqueued into the operation queue to ensure that the video is read before
any other operation is performed. This, however, forces a read operation on
on a video object even if there are no operations to apply (i.e.
_operations is empty).

This patch defers read operations until they are absolutely necessary.
This is done by storing the operations in a linked list (rather than a
vector), and adding a read operation to the head of the queue before
perform_operations() invokes each operation in the queue.

Signed-off-by: mahircg <mahircan.guel@intel.com>