### PR TITLE
Update Protobuf version on docker files

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -26,7 +26,7 @@ RUN cd /usr/src/gtest && cmake . && make && mv libgtest* /usr/lib/
 
 # Protobuf
 RUN cd / && git clone https://github.com/google/protobuf.git && \
-    cd protobuf && git checkout v3.6.1 && ./autogen.sh &&  \
+    cd protobuf && git checkout v3.9.0 && ./autogen.sh &&  \
     ./configure --prefix=/usr/local && \
     make -j $(cat /proc/cpuinfo | wc -l) && \
     make install && ldconfig && \


### PR DESCRIPTION
Updates the protobuf version to 3.9.0.

There is a bug on protobuf version 3.6.1 that will cause a segfault in VDMS sometimes. The bug was fixed in later versions. 3.9.0 has been working without problems in multiple systems