### PR TITLE
Add flag to optionally extract key-frame information on videos

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -16,6 +16,10 @@ AddOption('--prefix', dest='prefix',
                       metavar='DIR',
                       help='installation prefix')
 
+AddOption('--video-keyframes', action='append_const', dest='cflags',
+                      const='-DVIDEO_KEYFRAMES',
+                      help= 'Build KeyFrame Extraction feature for videos (Ubuntu 18 only)')
+
 def buildServer(env):
 
   env.Append(
@@ -70,7 +74,6 @@ def buildServer(env):
                   'src/vcl/Image.cc',
                   'src/vcl/TDBImage.cc',
                   'src/vcl/Video.cc',
-                  'src/vcl/KeyFrameParser.cc',
                   'src/vcl/DescriptorSet.cc',
                   'src/vcl/DescriptorSetData.cc',
                   'src/vcl/FaissDescriptorSet.cc',
@@ -78,6 +81,9 @@ def buildServer(env):
                   'src/vcl/TDBDenseDescriptorSet.cc',
                   'src/vcl/TDBSparseDescriptorSet.cc',
                 ]
+
+  if GetOption('cflags') and '-DVIDEO_KEYFRAMES' in GetOption('cflags') :
+    vdms_server_files.append('src/vcl/KeyFrameParser.cc')
 
   env.Program('vdms', vdms_server_files)
 

--- a/src/vcl/Video.cc
+++ b/src/vcl/Video.cc
@@ -171,10 +171,12 @@ std::vector<unsigned char> Video::get_encoded()
 
 const KeyFrameList& Video::get_key_frame_list()
 {
+    #if VIDEO_KEYFRAMES
     if (_key_frame_list.empty()) {
         VCL::KeyFrameParser parser(_video_id);
         _key_frame_list = parser.parse();
     }
+    #endif
     return _key_frame_list;
 }
 

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -43,9 +43,7 @@ test_sources = ['main.cc',
                 'unit_tests/DescriptorSetStore_test.cc',
               ]
 
-query_tests = testenv.Program(
-                'unit_test',
-                [ '../src/QueryHandler.o',
+objects_list = [ '../src/QueryHandler.o',
                   '../src/SearchExpression.o',
                   '../src/VDMSConfig.o',
                   '../src/RSCommand.o',
@@ -66,7 +64,6 @@ query_tests = testenv.Program(
                   '../src/vcl/Image.o',
                   '../src/vcl/TDBImage.o',
                   '../src/vcl/Video.o',
-                  '../src/vcl/KeyFrameParser.o',
                   '../src/vcl/DescriptorSet.o',
                   '../src/vcl/DescriptorSetData.o',
                   '../src/vcl/FaissDescriptorSet.o',
@@ -74,5 +71,9 @@ query_tests = testenv.Program(
                   '../src/vcl/TDBDenseDescriptorSet.o',
                   '../src/vcl/TDBSparseDescriptorSet.o',
                   test_sources
-                ],
-               )
+                ]
+
+if GetOption('cflags') and '-DVIDEO_KEYFRAMES' in GetOption('cflags') :
+  objects_list.append('../src/vcl/KeyFrameParser.o')
+
+query_tests = testenv.Program( 'unit_test', objects_list)

--- a/tests/unit_tests/Video_test.cc
+++ b/tests/unit_tests/Video_test.cc
@@ -663,6 +663,7 @@ TEST_F(VideoTest, CropWrite)
 
 TEST_F(VideoTest, KeyFrameExtractionSuccess)
 {
+    #if VIDEO_KEYFRAMES
     try {
         VCL::VideoTest video_data(_video_path_mp4_h264);
 
@@ -678,6 +679,7 @@ TEST_F(VideoTest, KeyFrameExtractionSuccess)
         print_exception(e);
         ASSERT_TRUE(false);
     }
+    #endif
 }
 
 TEST_F(VideoTest, KeyFrameExtractionFailure)


### PR DESCRIPTION
There is currently an incompatibility issue because of video encoding/decoding libraries on the develop branch. Some interfaces are not available on default Ubuntu 16 libraries.

This patch adds a flag that has to be specifically used in order to compile keyframe extraction.