### PR TITLE
Allow object creation from local files in server

### DIFF
--- a/src/VideoCommand.cc
+++ b/src/VideoCommand.cc
@@ -135,7 +135,14 @@ int AddVideo::construct_protobuf(
     int node_ref = get_value<int>(cmd, "_ref",
                                   query.get_available_reference());
 
-    VCL::Video video((void*)blob.data(), blob.size());
+    const std::string from_server_file = get_value<std::string>(cmd,
+                                                        "from_server_file", "");
+    VCL::Video video;
+    if (from_server_file.empty())
+        video = VCL::Video((void*)blob.data(), blob.size());
+    else
+        video = VCL::Video(from_server_file);
+
 
     // Key frame extraction works on binary stream data, without encoding. We
     // check whether key-frame extraction is to be applied, and if so, we
@@ -205,6 +212,12 @@ Json::Value AddVideo::construct_responses(
     ret[_cmd_name] = RSCommand::check_responses(response);
 
     return ret;
+}
+
+bool AddVideo::need_blob(const Json::Value& cmd)
+{
+    const Json::Value& add_video_cmd = cmd[_cmd_name];
+    return !(add_video_cmd.isMember("from_server_file"));
 }
 
 //========= UpdateVideo definitions =========

--- a/src/VideoCommand.h
+++ b/src/VideoCommand.h
@@ -85,7 +85,7 @@ namespace VDMS {
                 protobufs::queryMessage &response,
                 const std::string &blob);
 
-        bool need_blob(const Json::Value& cmd) { return true; }
+        bool need_blob(const Json::Value& cmd);
     };
 
     class UpdateVideo: public VideoCommand

--- a/tests/python/TestVideos.py
+++ b/tests/python/TestVideos.py
@@ -96,6 +96,53 @@ class TestVideos(TestCommand.TestCommand):
         for i in range(0, number_of_inserts):
             self.assertEqual(response[i]["AddVideo"]["status"], 0)
 
+    def test_addVideoFromLocalFile_invalid_command(self):
+
+        # The test is meant to fail if both blob and a local file are specified
+        db = self.create_connection()
+
+        with open("../test_videos/Megamind.avi", 'rb') as fd:
+            video_blob = fd.read()
+
+        video_params = {}
+        video_params["from_server_file"] = "BigFile.mp4"
+        video_params["codec"]           = "h264"
+
+        query = {}
+        query["AddVideo"] = video_params
+
+        response, obj_array = db.query([query], [[video_blob]])
+        self.assertEqual(response[0]["status"], -1)
+
+    def test_addVideoFromLocalFile_file_not_found(self):
+
+        db = self.create_connection()
+
+        video_params = {}
+        video_params["from_server_file"] = "BigFile.mp4"
+        video_params["codec"]           = "h264"
+
+        query = {}
+        query["AddVideo"] = video_params
+
+        response, obj_array = db.query([query], [[]])
+        self.assertEqual(response[0]["status"], -1)
+
+    def test_addVideoFromLocalFile_success(self):
+
+        db = self.create_connection()
+
+        video_params = {}
+        video_params["from_server_file"] = "../../tests/videos/Megamind.mp4"
+        video_params["codec"]           = "h264"
+
+        query = {}
+        query["AddVideo"] = video_params
+
+        response, obj_array = db.query([query], [[]])
+        self.assertEqual(response[0]["AddVideo"]["status"], 0)
+
+
     def test_extractKeyFrames(self):
 
         db = self.create_connection()

--- a/utils/src/api_schema/api_schema.json
+++ b/utils/src/api_schema/api_schema.json
@@ -663,13 +663,14 @@
 
     "AddVideo": {
       "properties": {
-        "_ref":         { "$ref": "#/definitions/refInt" },
-        "index_frames": { "type": "boolean" },
-        "codec":        { "$ref": "#/definitions/vidCodecString" },
-        "container":    { "$ref": "#/definitions/vidContainerString" },
-        "link":         { "$ref": "#/definitions/blockLink" },
-        "operations":   { "$ref": "#/definitions/blockVideoOperations" },
-        "properties":   { "type": "object" }
+        "_ref":             { "$ref": "#/definitions/refInt" },
+        "index_frames":     { "type": "boolean" },
+        "from_server_file": { "type": "string"},
+        "codec":            { "$ref": "#/definitions/vidCodecString" },
+        "container":        { "$ref": "#/definitions/vidContainerString" },
+        "link":             { "$ref": "#/definitions/blockLink" },
+        "operations":       { "$ref": "#/definitions/blockVideoOperations" },
+        "properties":       { "type": "object" }
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
This patch introduces 'from_local_file' parameter to AddVideo command,
that allows object creation from local video files in server instead of
blobs transferred from the client.

Signed-off-by: mahircg <mahircan.guel@intel.com>