### PR TITLE
Token permissions again

### DIFF
--- a/.github/workflows/_CI_coverage_compare.yml
+++ b/.github/workflows/_CI_coverage_compare.yml
@@ -20,15 +20,14 @@ on:
         description: "The Python Coverage for source"
         type: string
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-
 jobs:
     compare_coverage:
       name: Compare Reported Coverage
       runs-on: ubuntu-latest
+      permissions:
+        contents: write
+        issues: write
+        pull-requests: write
       steps:
         - name: Comment Coverage
           uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1

--- a/.github/workflows/_CI_update.yml
+++ b/.github/workflows/_CI_update.yml
@@ -12,9 +12,6 @@ on:
           description: "Status of coverage tests (passed/failed)"
           type: string
 
-permissions:
-  contents: write
-
 jobs:
     commit_job:
         permissions:


### PR DESCRIPTION
write permissions still at wrong level in two scripts so we're still getting a 0 for OSSF Scorecard token-permissions check.  Testing if moving to the jobs level will still work.