### PR TITLE
182 erroneous read only on server start

### DIFF
--- a/src/PMGDQuery.cc
+++ b/src/PMGDQuery.cc
@@ -676,6 +676,8 @@ void PMGDQuery::QueryNode(int ref, const std::string &tag,
                           const Json::Value &constraints,
                           const Json::Value &results, bool unique,
                           bool intermediate_query) {
+  _readonly = false;
+
   PMGDCmd *cmdquery = new PMGDCmd();
   cmdquery->set_cmd_id(PMGDCmd::QueryNode);
   cmdquery->set_cmd_grp_id(_current_group_id);
@@ -713,6 +715,8 @@ void PMGDQuery::QueryEdge(int ref, int src_ref, int dest_ref,
                           const std::string &tag,
                           const Json::Value &constraints,
                           const Json::Value &results, bool unique) {
+  _readonly = false;
+
   PMGDCmd *cmdquery = new PMGDCmd();
   cmdquery->set_cmd_id(PMGDCmd::QueryEdge);
   cmdquery->set_cmd_grp_id(_current_group_id);

--- a/tests/unit_tests/RemoteConnection_test.cc
+++ b/tests/unit_tests/RemoteConnection_test.cc
@@ -511,17 +511,6 @@ TEST_F(RemoteConnectionTest, ImageTransactionRollback) {
     std::array<char, 8> buffer;
     std::string result;
 
-    std::string string_query_simple_add_image("[ \
-       { \
-          \"AddImage\": { \
-              \"properties\": { \
-                  \"name\": \"SampleImage\" \
-              }, \
-              \"format\": \"png\" \
-          } \
-      } \
-    ]");
-
     std::string string_query_image_rollback("[");
     string_query_image_rollback += " \
       { \
@@ -557,7 +546,7 @@ TEST_F(RemoteConnectionTest, ImageTransactionRollback) {
                                                 // been initialized
 
     VDMS::protobufs::queryMessage proto_query;
-    proto_query.set_json(string_query_simple_add_image);
+    proto_query.set_json(string_query_image_rollback);
 
     std::string image;
     std::ifstream file("test_images/brain.png",
@@ -570,9 +559,7 @@ TEST_F(RemoteConnectionTest, ImageTransactionRollback) {
       std::cout << "error" << std::endl;
 
     proto_query.add_blobs(image);
-
-    VDMS::protobufs::queryMessage response;
-    query_handler.process_query(proto_query, response);
+    proto_query.add_blobs(image);
 
     // Get initial number of objects stored in S3
     std::unique_ptr<FILE, decltype(&pclose)> pipe1(popen(s3_num_objects_cmd, "r"), pclose);
@@ -583,12 +570,8 @@ TEST_F(RemoteConnectionTest, ImageTransactionRollback) {
       result += buffer.data();
     }
     s3_num_objects = stoi(result);
-    result.clear();
 
-    proto_query.clear_blobs();
-    proto_query.set_json(string_query_image_rollback);
-    proto_query.add_blobs(image);
-    proto_query.add_blobs(image);
+    VDMS::protobufs::queryMessage response;
     query_handler.process_query(proto_query, response);
 
     Json::Reader json_reader;
@@ -636,6 +619,7 @@ TEST_F(RemoteConnectionTest, ImageTransactionRollback) {
     EXPECT_EQ(json_response[1]["FindImage"]["info"], "No entities found");
 
     // Make sure number of objects in S3 is still the same
+    result.clear();
     std::unique_ptr<FILE, decltype(&pclose)> pipe2(popen(s3_num_objects_cmd, "r"), pclose);
     if (!pipe2) {
       throw std::runtime_error("popen() failed!");
@@ -648,5 +632,60 @@ TEST_F(RemoteConnectionTest, ImageTransactionRollback) {
 
   } catch (...) {
     printErrorMessage("ImageTransactionRollback");
+  }
+}
+
+TEST_F(RemoteConnectionTest, FindImageEmptyDB) {
+  try {
+    VDMS::Server VDMS_server("unit_tests/config-aws-tests.json", "", "", "");
+
+    QueryHandlerPMGD query_handler;
+    query_handler.reset_autodelete_init_flag(); // set flag to show autodelete queue has
+                                                // been initialized
+
+    VDMS::protobufs::queryMessage proto_query;
+    VDMS::protobufs::queryMessage response;
+
+    Json::Reader json_reader;
+    Json::Value json_response;
+
+    std::string string_query_image_lookup("[");
+    string_query_image_lookup += " \
+          { \
+              \"FindImage\": { \
+                  \"results\": { \
+                      \"list\": [\"name\"] \
+                  }, \
+                  \"constraints\": { \
+                      \"name\": [ \"==\", \"NonExistentImage1\" ] \
+                  } \
+              } \
+          }, \
+          { \
+              \"FindImage\": { \
+                  \"results\": { \
+                      \"list\": [\"name\"] \
+                  }, \
+                  \"constraints\": { \
+                      \"name\": [ \"==\", \"NonExistentImage2\" ] \
+                  } \
+              } \
+          } \
+      ";
+    string_query_image_lookup += "]";
+
+    proto_query.clear_blobs();
+    proto_query.set_json(string_query_image_lookup);
+
+    query_handler.process_query(proto_query, response);
+    json_reader.parse(response.json(), json_response);
+
+    EXPECT_EQ(json_response[0]["FindImage"]["status"].asString(), "0");
+    EXPECT_EQ(json_response[0]["FindImage"]["info"], "No entities found");
+    EXPECT_EQ(json_response[1]["FindImage"]["status"].asString(), "0");
+    EXPECT_EQ(json_response[1]["FindImage"]["info"], "No entities found");
+
+  } catch (...) {
+    printErrorMessage("FindImageEmptyDB");
   }
 }

--- a/tests/unit_tests/RemoteConnection_test.cc
+++ b/tests/unit_tests/RemoteConnection_test.cc
@@ -511,6 +511,17 @@ TEST_F(RemoteConnectionTest, ImageTransactionRollback) {
     std::array<char, 8> buffer;
     std::string result;
 
+    std::string string_query_simple_add_image("[ \
+       { \
+          \"AddImage\": { \
+              \"properties\": { \
+                  \"name\": \"SampleImage\" \
+              }, \
+              \"format\": \"png\" \
+          } \
+      } \
+    ]");
+
     std::string string_query_image_rollback("[");
     string_query_image_rollback += " \
       { \
@@ -546,7 +557,7 @@ TEST_F(RemoteConnectionTest, ImageTransactionRollback) {
                                                 // been initialized
 
     VDMS::protobufs::queryMessage proto_query;
-    proto_query.set_json(string_query_image_rollback);
+    proto_query.set_json(string_query_simple_add_image);
 
     std::string image;
     std::ifstream file("test_images/brain.png",
@@ -559,7 +570,9 @@ TEST_F(RemoteConnectionTest, ImageTransactionRollback) {
       std::cout << "error" << std::endl;
 
     proto_query.add_blobs(image);
-    proto_query.add_blobs(image);
+
+    VDMS::protobufs::queryMessage response;
+    query_handler.process_query(proto_query, response);
 
     // Get initial number of objects stored in S3
     std::unique_ptr<FILE, decltype(&pclose)> pipe1(popen(s3_num_objects_cmd, "r"), pclose);
@@ -570,8 +583,12 @@ TEST_F(RemoteConnectionTest, ImageTransactionRollback) {
       result += buffer.data();
     }
     s3_num_objects = stoi(result);
+    result.clear();
 
-    VDMS::protobufs::queryMessage response;
+    proto_query.clear_blobs();
+    proto_query.set_json(string_query_image_rollback);
+    proto_query.add_blobs(image);
+    proto_query.add_blobs(image);
     query_handler.process_query(proto_query, response);
 
     Json::Reader json_reader;
@@ -619,7 +636,6 @@ TEST_F(RemoteConnectionTest, ImageTransactionRollback) {
     EXPECT_EQ(json_response[1]["FindImage"]["info"], "No entities found");
 
     // Make sure number of objects in S3 is still the same
-    result.clear();
     std::unique_ptr<FILE, decltype(&pclose)> pipe2(popen(s3_num_objects_cmd, "r"), pclose);
     if (!pipe2) {
       throw std::runtime_error("popen() failed!");


### PR DESCRIPTION
This PR fixes an unexpected query response containing an exception message when running a Query Edge/Node transaction on a new/empty PMGD db instance.

Closes #182 
Closes #307 